### PR TITLE
Support options from pydocstyle 6.2.0 and 6.3.0

### DIFF
--- a/flake8_docstrings.py
+++ b/flake8_docstrings.py
@@ -13,7 +13,9 @@ try:
 
     module_name = "pydocstyle"
 
-    pydocstyle_version = tuple(int(num) for num in pep257.__version__.split("."))
+    pydocstyle_version = tuple(
+        int(num) for num in pep257.__version__.split(".")
+    )
     supports_ignore_inline_noqa = pydocstyle_version > (5, 1, 1)
     supports_property_decorators = pydocstyle_version >= (6, 2, 0)
     supports_ignore_self_only_init = pydocstyle_version >= (6, 3, 0)
@@ -105,7 +107,9 @@ class pep257Checker:
         if supports_property_decorators:
             from pydocstyle.config import ConfigurationParser
 
-            default_property_decorators = ConfigurationParser.DEFAULT_PROPERTY_DECORATORS
+            default_property_decorators = (
+                ConfigurationParser.DEFAULT_PROPERTY_DECORATORS
+            )
             parser.add_option(
                 "--property-decorators",
                 action="store",
@@ -152,13 +156,15 @@ class pep257Checker:
                 else None
             )
         if supports_ignore_self_only_init:
-            check_source_kwargs["ignore_self_only_init"] = self.ignore_self_only_init
+            check_source_kwargs[
+                "ignore_self_only_init"
+            ] = self.ignore_self_only_init
 
         return self.checker.check_source(
             self.source,
             self.filename,
             ignore_decorators=self.ignore_decorators,
-            **check_source_kwargs
+            **check_source_kwargs,
         )
 
     def _check_source(self):

--- a/flake8_docstrings.py
+++ b/flake8_docstrings.py
@@ -16,7 +16,7 @@ try:
     pydocstyle_version = tuple(
         int(num) for num in pep257.__version__.split(".")
     )
-    supports_ignore_inline_noqa = pydocstyle_version > (5, 1, 1)
+    supports_ignore_inline_noqa = pydocstyle_version >= (6, 0, 0)
     supports_property_decorators = pydocstyle_version >= (6, 2, 0)
     supports_ignore_self_only_init = pydocstyle_version >= (6, 3, 0)
 except ImportError:


### PR DESCRIPTION
# What's new
- Support for `--property-decorators` (new in pydocstyle 6.2.0)
  - PyCQA/pydocstyle#546
  - #47
- Support for `--ignore-self-only-init` (new in pydocstyle 6.3.0)
  - PyCQA/pydocstyle#560

# Implementation details
- Help messages were copied from pydocstyle.
- The pydocstyle version is checked, the options are only added to the CLI and passed to pydocstyle if the version supports it (previously: try-catch construct to check if `--ignore-noqa` from pydocstyle 6.0.0 is available).

# How to test
Example file `code.py`:
```python
"""This is my module."""
from functools import cached_property


class MyClass:
    """This is my class."""

    def __init__(self):
        # missing docstring, raises D107 unless '--ignore-self-only-init' is set
        pass

    @property
    def my_property(self) -> str:
        """This is my property."""
        # non-imperative docstring, raises D401 if 'property' is not in '--property-decorators'
        return "property"

    @cached_property
    def my_cached_property(self) -> str:
        """This is my cached property."""
        # non-imperative docstring, raises D401 if 'cached_property' is not in '--property-decorators'
        return "cached_property"
```

# Addendum
Suggested `HISTORY.rst` entries for the next release:
```rst
- Add ``--ignore-self-only-init`` option to suppress D107 ("missing method
  docstring") if ``__init__`` has no parameters other than ``self``.
  (Requires pydocstyle >= 6.3.0)

- Add ``--property-decorators`` option to suppress D401 ("not in imperative
  mood") for docstrings of properties, defaulting to ``property``,
  ``cached_property``, and ``functools.cached_property``.
  (Requires pydocstyle >= 6.2.0)
```