### PR TITLE
docstrings: allow pydocstyle dev versions

### DIFF
--- a/flake8_docstrings.py
+++ b/flake8_docstrings.py
@@ -14,7 +14,7 @@ try:
     module_name = "pydocstyle"
 
     pydocstyle_version = tuple(
-        int(num) for num in pep257.__version__.split(".")
+        int(num) if num.isdigit() else 0 for num in pep257.__version__.split(".")
     )
     supports_ignore_inline_noqa = pydocstyle_version >= (6, 0, 0)
     supports_property_decorators = pydocstyle_version >= (6, 2, 0)

--- a/flake8_docstrings.py
+++ b/flake8_docstrings.py
@@ -14,7 +14,8 @@ try:
     module_name = "pydocstyle"
 
     pydocstyle_version = tuple(
-        int(num) if num.isdigit() else 0 for num in pep257.__version__.split(".")
+        int(num) if num.isdigit() else 0
+        for num in pep257.__version__.split(".")
     )
     supports_ignore_inline_noqa = pydocstyle_version >= (6, 0, 0)
     supports_property_decorators = pydocstyle_version >= (6, 2, 0)


### PR DESCRIPTION
if pydocstyle is build from a git clone the version parsing fails as the version is something like '0.0.0-dev'.
Fix the parsing of 0-dev by falling back to 0